### PR TITLE
Revert "Bump spring-security-core from 5.2.1.RELEASE to 5.2.11.RELEASE in /issuer"

### DIFF
--- a/issuer/pom.xml
+++ b/issuer/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>5.2.11.RELEASE</version>
+            <version>5.2.1.RELEASE</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Reverts felleslosninger/digdir-camp-2021-VC#65